### PR TITLE
Поддержка кросс-компиляции в Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
-CC       = gcc
-LIBS     = -lreadline
-CFLAGS   = -O2 -g -Wno-unused-result -Wunused
+CFLAGS ?= -g -O2
+override CFLAGS += -Wno-unused-result -Wunused
 
 OBJS     = hdlc.o  qcio.o memio.o chipconfig.o
 
@@ -8,7 +7,7 @@ OBJS     = hdlc.o  qcio.o memio.o chipconfig.o
 
 all:    qcommand qrmem qrflash qdload mibibsplit qwflash qwdirect qefs qnvram qblinfo qident qterminal qbadblock qflashparm
 
-clean: 
+clean:
 	rm *.o
 	rm $(all)
 
@@ -21,50 +20,35 @@ sahara.o: sahara.c
 chipconfig.o: chipconfig.c
 memio.o: memio.c
 ptable.o: ptable.c
-#	$(CC) -c qcio.c
 
 qcommand: qcommand.o  $(OBJS)
-	gcc $^ -o $@ $(LIBS)
 
 qrmem: qrmem.o $(OBJS)
-	gcc $^ -o $@ $(LIBS)
 
 qrflash: qrflash.o $(OBJS) ptable.o
-	gcc $^ -o $@ $(LIBS)
 
 qwflash: qwflash.o $(OBJS)
-	gcc $^ -o $@ $(LIBS)
 
 #qwimage: qwimage.o $(OBJS)
-#	gcc $^ -o $@ $(LIBS)
 
 qdload: qdload.o sahara.o $(OBJS)  ptable.o
-	gcc $^ -o $@ $(LIBS)
 
 qwdirect: qwdirect.o $(OBJS)  ptable.o
-	gcc $^ -o $@ $(LIBS)
-	
+
 qefs  : qefs.o efsio.o $(OBJS)
-	gcc $^ -o $@ $(LIBS)
 
 qnvram  : qnvram.o $(OBJS)
-	gcc $^ -o $@ $(LIBS)
-	
+
 mibibsplit: mibibsplit.o $(OBJS)
-	gcc $^ -o $@ $(LIBS)
 
 qblinfo:    qblinfo.o $(OBJS)
-	gcc $^ -o $@  $(LIBS)
 
 qident:      qident.o $(OBJS)
-	gcc $^ -o $@ $(LIBS)
 
 qterminal:   qterminal.o $(OBJS)
-	gcc $^ -o $@ $(LIBS)
 
 qbadblock:   qbadblock.o $(OBJS)  ptable.o
-	gcc $^ -o $@ $(LIBS)
 
 qflashparm:  qflashparm.o $(OBJS)
-	gcc $^ -o $@ $(LIBS)
-	
+
+qterminal qcommand: override LDLIBS+=-lreadline -lncurses


### PR DESCRIPTION
- по возможности используем встроенные правила Make
- не хардкодим имя компилятора